### PR TITLE
feat: Add toggle for securityContext and PodSecurityContext

### DIFF
--- a/charts/sops-operator/Chart.yaml
+++ b/charts/sops-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sops-operator
 description: sops-operator
 type: application
-version: 0.0.0
-appVersion: "0.0.0"
+version: 0.4.1
+appVersion: "0.4.1"
 home: https://github.com/peak-scale/sops-operator
 icon: https://avatars.githubusercontent.com/u/129185620?s=48&v=4
 keywords:

--- a/charts/sops-operator/README.md
+++ b/charts/sops-operator/README.md
@@ -35,11 +35,11 @@ The following Values are available for this chart.
 | global.jobs.kubectl.image.repository | string | `"clastix/kubectl"` | Set the image repository of the helm chart job |
 | global.jobs.kubectl.image.tag | string | `""` | Set the image tag of the helm chart job |
 | global.jobs.kubectl.nodeSelector | object | `{}` | Set the node selector |
-| global.jobs.kubectl.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
+| global.jobs.kubectl.podSecurityContext | object | `{"enabled":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
 | global.jobs.kubectl.priorityClassName | string | `""` | Set a pod priorityClassName |
 | global.jobs.kubectl.resources | object | `{}` | Job resources |
 | global.jobs.kubectl.restartPolicy | string | `"Never"` | Set the restartPolicy |
-| global.jobs.kubectl.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the job containers. |
+| global.jobs.kubectl.securityContext | object | `{"enabled":true,"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the job containers. |
 | global.jobs.kubectl.tolerations | list | `[]` | Set list of tolerations |
 | global.jobs.kubectl.topologySpreadConstraints | list | `[]` | Set Topology Spread Constraints |
 | global.jobs.kubectl.ttlSecondsAfterFinished | int | `60` | Sets the ttl in seconds after a finished certgen job is deleted. Set to -1 to never delete. |
@@ -71,7 +71,7 @@ The following Values are available for this chart.
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Set the node selector |
 | podAnnotations | object | `{}` | Annotations to add |
-| podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Set the securityContext |
+| podSecurityContext | object | `{"enabled":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Set the securityContext |
 | priorityClassName | string | `""` | Set the priority class name of the Capsule pod |
 | rbac.enabled | bool | `true` | Enable bootstraping of RBAC resources |
 | rbac.secretsRole.enabled | bool | `true` |  |
@@ -79,7 +79,7 @@ The following Values are available for this chart.
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":10080}}` | Configure the readiness probe using Deployment probe spec |
 | replicaCount | int | `1` | Amount of replicas |
 | resources | object | `{}` | Set the resource requests/limits |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | Set the securityContext for the container |
+| securityContext | object | `{"enabled":true,"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | Set the securityContext for the container |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | The name of the service account to use. |

--- a/charts/sops-operator/templates/crd-lifecycle/job.yaml
+++ b/charts/sops-operator/templates/crd-lifecycle/job.yaml
@@ -21,9 +21,8 @@ spec:
         {{- include "helm.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: {{ $.Values.global.jobs.kubectl.restartPolicy }}
-      {{- with $.Values.global.jobs.kubectl.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
+      {{- if $.Values.global.jobs.kubectl.podSecurityContext.enabled }}
+      securityContext: {{- omit $.Values.global.jobs.kubectl.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.global.jobs.kubectl.nodeSelector }}
       nodeSelector:
@@ -53,9 +52,8 @@ spec:
       - name: crds-hook
         image: {{ include "helm.jobsFullyQualifiedDockerImage" $ }}
         imagePullPolicy: {{ .Values.global.jobs.kubectl.image.pullPolicy }}
-        {{- with $.Values.global.jobs.kubectl.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
+        {{- if $.Values.global.jobs.kubectl.securityContext.enabled }}
+        securityContext: {{- omit $.Values.global.jobs.kubectl.securityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
         command:
         - sh

--- a/charts/sops-operator/templates/deployment.yaml
+++ b/charts/sops-operator/templates/deployment.yaml
@@ -23,16 +23,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "helm.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if $.Values.podSecurityContext.enabled }}
+      securityContext: {{- omit $.Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       volumes:
         - name: sops-volume
           emptyDir:
             sizeLimit: 500Mi
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if $.Values.securityContext.enabled }}
+          securityContext: {{- omit $.Values.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.registry | trimSuffix "/" }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/sops-operator/values.yaml
+++ b/charts/sops-operator/values.yaml
@@ -25,10 +25,12 @@ global:
       ttlSecondsAfterFinished: 60
       # -- Security context for the job pods.
       podSecurityContext:
+        enabled: true
         seccompProfile:
           type: "RuntimeDefault"
       # -- Security context for the job containers.
       securityContext:
+        enabled: true
         allowPrivilegeEscalation: false
         capabilities:
           drop:
@@ -112,11 +114,13 @@ podAnnotations: {}
 
 # -- Set the securityContext
 podSecurityContext:
+  enabled: true
   seccompProfile:
     type: RuntimeDefault
 
 # -- Set the securityContext for the container
 securityContext:
+  enabled: true
   allowPrivilegeEscalation: false
   capabilities:
     drop:


### PR DESCRIPTION
Sometimes you don't want to use the securityContext and PodSecurityContext (for example, when you use Security Context Constraints). Leaving the values to `null` does work when using helm directly, but not when implementing the chart by Argo. So, I've added a extra toggle. 

Also added the chart version in Chart.yaml, since this is the pod image tag that is deployed, which was currently 0.0.0.