### PR TITLE
fix(controller): provide error to sopsprovider status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ go.work.sum
 bin/
 coverage.out
 e2e/testdata/openbao/*enc.yaml
+config/

--- a/Makefile
+++ b/Makefile
@@ -234,9 +234,12 @@ e2e-init: sops openbao
 e2e-destroy: kind
 	$(KIND) delete cluster --name $(CLUSTER_NAME)
 
-e2e-install: e2e-load-image e2e-install-addon-helm e2e-install-distro
+e2e-install: e2e-install-addon-helm e2e-install-distro
 
-e2e-install-addon-helm:
+
+e2e-install-addon-helm: VERSION :=v0.0.0
+e2e-install-addon-helm: KO_TAGS :=v0.0.0
+e2e-install-addon-helm: e2e-load-image ko-build-all
 	helm upgrade \
 	    --dependency-update \
 		--debug \

--- a/internal/api/selectors.go
+++ b/internal/api/selectors.go
@@ -116,7 +116,7 @@ func (s *NamespacedSelector) MatchObjects(
 
 		objSelector, err = metav1.LabelSelectorAsSelector(s.LabelSelector)
 		if err != nil {
-			return nil, fmt.Errorf("invalid object selector: %w", err)
+			return nil, fmt.Errorf("invalid namespace selector: %w", err)
 		}
 	}
 
@@ -181,7 +181,7 @@ func MatchTypedObjects[T client.Object](
 	if selector.LabelSelector != nil {
 		objSelector, err = metav1.LabelSelectorAsSelector(selector.LabelSelector)
 		if err != nil {
-			return nil, fmt.Errorf("invalid object selector: %w", err)
+			return nil, fmt.Errorf("invalid object selector: %w, selector: %v", err, selector.LabelSelector)
 		}
 	}
 

--- a/internal/controllers/sopssecret_controller.go
+++ b/internal/controllers/sopssecret_controller.go
@@ -295,6 +295,7 @@ func (r *SopsSecretReconciler) reconcileSecret(
 		for k, v := range secret.Labels {
 			labels[k] = v
 		}
+
 		target.SetLabels(labels)
 
 		annotations := target.GetAnnotations()
@@ -305,6 +306,7 @@ func (r *SopsSecretReconciler) reconcileSecret(
 		for k, v := range secret.Annotations {
 			annotations[k] = v
 		}
+
 		target.SetAnnotations(annotations)
 
 		target.Data = map[string][]byte{}


### PR DESCRIPTION
Currently some errors are swallowed by the controller (eg. setting invalid selectors). This provides information on the `SopsProvider` resource