### PR TITLE
fix: handle SOPS type:int annotations and improve error messages

### DIFF
--- a/internal/controllers/secrets.go
+++ b/internal/controllers/secrets.go
@@ -152,7 +152,7 @@ func reconcileSecret(
 	}
 
 	if err := decryptor.Decrypt(origin.GetSopsMetadata(), item, log); err != nil {
-		return target, fmt.Errorf("secret could not be decrypted")
+		return target, fmt.Errorf("secret could not be decrypted: %w", err)
 	}
 
 	// Replicate Secret

--- a/internal/decryptor/sops_test.go
+++ b/internal/decryptor/sops_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2024 Peak Scale
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package decryptor
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestConvertInterfaceMapToStringMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]string
+	}{
+		{
+			name:     "nil input returns nil",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty map returns empty map",
+			input:    map[string]interface{}{},
+			expected: map[string]string{},
+		},
+		{
+			name: "string values preserved",
+			input: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "integer values converted to string (type:int fix)",
+			input: map[string]interface{}{
+				"port":     8080,
+				"replicas": 3,
+			},
+			expected: map[string]string{
+				"port":     "8080",
+				"replicas": "3",
+			},
+		},
+		{
+			name: "float values converted to string (type:float fix)",
+			input: map[string]interface{}{
+				"ratio":   0.5,
+				"percent": 99.9,
+			},
+			expected: map[string]string{
+				"ratio":   "0.5",
+				"percent": "99.9",
+			},
+		},
+		{
+			name: "boolean values converted to string (type:bool fix)",
+			input: map[string]interface{}{
+				"enabled":  true,
+				"disabled": false,
+			},
+			expected: map[string]string{
+				"enabled":  "true",
+				"disabled": "false",
+			},
+		},
+		{
+			name: "mixed types all converted correctly",
+			input: map[string]interface{}{
+				"name":     "my-service",
+				"port":     8080,
+				"enabled":  true,
+				"ratio":    0.75,
+				"password": "secret123",
+			},
+			expected: map[string]string{
+				"name":     "my-service",
+				"port":     "8080",
+				"enabled":  "true",
+				"ratio":    "0.75",
+				"password": "secret123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertInterfaceMapToStringMap(tt.input)
+
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected length %d, got %d", len(tt.expected), len(result))
+			}
+
+			for k, v := range tt.expected {
+				if result[k] != v {
+					t.Errorf("key %q: expected %q, got %q", k, v, result[k])
+				}
+			}
+		})
+	}
+}
+
+// TestSopsSecretRawUnmarshal tests that the intermediate struct can handle
+// non-string values that SOPS outputs when using type annotations.
+// This is the root cause of issue #335.
+func TestSopsSecretRawUnmarshal(t *testing.T) {
+	// This JSON simulates what SOPS outputs when decrypting values with type:int
+	// Note: port value is 8080 (unquoted integer), not "8080" (string)
+	jsonWithTypeInt := `{
+		"spec": {
+			"secrets": [{
+				"name": "test-secret",
+				"stringData": {
+					"port": 8080,
+					"host": "localhost",
+					"enabled": true,
+					"ratio": 0.5
+				},
+				"data": {
+					"count": 42
+				}
+			}]
+		}
+	}`
+
+	var target sopsSecretRaw
+	err := json.Unmarshal([]byte(jsonWithTypeInt), &target)
+	if err != nil {
+		t.Fatalf("failed to unmarshal JSON with type:int values: %v", err)
+	}
+
+	if len(target.Spec.Secrets) != 1 {
+		t.Fatalf("expected 1 secret, got %d", len(target.Spec.Secrets))
+	}
+
+	secret := target.Spec.Secrets[0]
+
+	// Verify StringData can hold non-string types
+	stringData := convertInterfaceMapToStringMap(secret.StringData)
+	expectedStringData := map[string]string{
+		"port":    "8080",
+		"host":    "localhost",
+		"enabled": "true",
+		"ratio":   "0.5",
+	}
+
+	for k, expected := range expectedStringData {
+		if stringData[k] != expected {
+			t.Errorf("stringData[%q]: expected %q, got %q", k, expected, stringData[k])
+		}
+	}
+
+	// Verify Data can hold non-string types
+	data := convertInterfaceMapToStringMap(secret.Data)
+	if data["count"] != "42" {
+		t.Errorf("data[count]: expected \"42\", got %q", data["count"])
+	}
+}
+
+// TestOriginalStructFailsWithTypeInt demonstrates the original bug - trying to
+// unmarshal SOPS output with type:int into map[string]string fails.
+func TestOriginalStructFailsWithTypeInt(t *testing.T) {
+	// This is what the original code tried to do - unmarshal into map[string]string
+	type originalStringData struct {
+		StringData map[string]string `json:"stringData"`
+	}
+
+	jsonWithTypeInt := `{"stringData": {"port": 8080}}`
+
+	var target originalStringData
+	err := json.Unmarshal([]byte(jsonWithTypeInt), &target)
+
+	// This SHOULD fail because Go cannot unmarshal a JSON number into a string
+	if err == nil {
+		t.Error("expected unmarshal to fail when JSON number is assigned to string field, but it succeeded")
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes the decryption failure for SOPS secrets with `type:int` (and other non-string) annotations, as reported in #335.

### Changes:

1. **Fix type mismatch in JSON unmarshaling** (`internal/decryptor/sops.go`)
   - Added intermediate structs (`sopsSecretRaw`, `sopsSecretItemRaw`) that use `map[string]interface{}` instead of `map[string]string`
   - Added `convertInterfaceMapToStringMap()` helper to convert all values to strings
   - This handles SOPS output where integers are unquoted JSON numbers (e.g., `{"port": 8080}` instead of `{"port": "8080"}`)

2. **Fix error suppression** (`internal/controllers/secrets.go`)
   - Changed `fmt.Errorf("secret could not be decrypted")` to `fmt.Errorf("secret could not be decrypted: %w", err)`
   - This preserves the actual decryption error for better debugging

3. **Added unit tests** (`internal/decryptor/sops_test.go`)
   - Tests for `convertInterfaceMapToStringMap()` with various types (strings, integers, floats, booleans, mixed)
   - Test verifying the intermediate struct can unmarshal SOPS output with type annotations
   - Test demonstrating that the original `map[string]string` fails with type:int values

## Test plan

- [x] All existing tests pass
- [x] New unit tests pass (`go test ./internal/decryptor/ -v`)
- [x] Build succeeds (`go build ./...`)
- [ ] Manual testing with SOPS secrets using `type:int` annotations

## Reproduction

Before this fix, encrypting a secret with unquoted integers:
```yaml
stringData:
  port: 8080
```

Would fail with a generic "secret could not be decrypted" error because SOPS preserves the `type:int` annotation and outputs `{"port": 8080}` (unquoted), which Go's JSON unmarshaler cannot convert to a string.

After this fix, the decryption succeeds and converts the integer to its string representation `"8080"`.

Fixes #335